### PR TITLE
feat: add `resendConfirmCode()` API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Directories.
 .cache
+.idea
 coverage
 node_modules
 

--- a/packages/cognito/index.ts
+++ b/packages/cognito/index.ts
@@ -119,6 +119,21 @@ export default class CognitoClient {
     });
   }
 
+  /*
+   * Call this when you need to request the OTP code again.
+   */
+  resendConfirmCode(username: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.getCognitoUser(username).resendConfirmationCode(function (err, result) {
+        if (err) {
+          return reject(err);
+        }
+
+        resolve(result);
+      });
+    });
+  }
+
   private getCognitoUser(username: string) {
     return new CognitoUser({
       Username: username,


### PR DESCRIPTION
Manually tested cases:

- nominal case: create new user, receive OTP code, request OTP code again, input the second OTP code, verify it, receive good answer (as expected)
- error case: create new user, receive OTP code, request OTP code again, wrong OTP code (not first, not second), receive `CodeMismatchException` (as expected)
